### PR TITLE
Adds support for assets now that they have their own url in 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0"
+        "craftcms/cms": "^3.4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/SequentialEdit.php
+++ b/src/SequentialEdit.php
@@ -105,6 +105,10 @@ class SequentialEdit extends Plugin
                 return $this->displayHook('user', $context);
             });
 
+            Craft::$app->view->hook('cp.assets.edit.details', function(array &$context) {
+                return $this->displayHook('asset', $context);
+            });
+
             // Remove this session's queued item if this is not an edit action of any kind
             if ($request->isCpRequest && !$request->isAjax && !$requestContainsActionTrigger) {
                 $this->general->destroyQueueOnAnythingButEdits();
@@ -149,7 +153,7 @@ class SequentialEdit extends Plugin
 
     protected function displayHook($type, $context)
     {
-        $element = $context[$type];
+        $element = $context['element'];
 
         if ($element) {
             switch ($type) {
@@ -164,6 +168,10 @@ class SequentialEdit extends Plugin
                 case 'user':
                     $elementType = 'craft\elements\User';
                     $tString = '{n, plural, =1{user} other{users}}';
+                    break;
+                case 'asset':
+                    $elementType = 'craft\elements\Asset';
+                    $tString = '{n, plural, =1{asset} other{assets}}';
                     break;
             }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -22,5 +22,6 @@ class Settings extends Model
         'craft\elements\Entry',
         'craft\elements\Category',
         'craft\elements\User',
+        'craft\elements\Asset',
     ];
 }

--- a/src/services/SequentialEditService.php
+++ b/src/services/SequentialEditService.php
@@ -157,6 +157,7 @@ class SequentialEditService extends Component
                 switch ($controller) {
                     case 'entries':
                     case 'categories':
+                    case 'assets':
                         if (!isset($segments[2])) {
                             $destroyQueue = true;
                         } else {


### PR DESCRIPTION
Assets borrow _a lot_ of functionality from entries in Craft 3.4 so I copied over a lot of what you're doing for entries to assets!

This requires the additional PR on `craftcms/cms` for the asset details display,

https://github.com/craftcms/cms/pull/5560