### PR TITLE
Fixes Category Edit Error

### DIFF
--- a/src/SequentialEdit.php
+++ b/src/SequentialEdit.php
@@ -153,7 +153,14 @@ class SequentialEdit extends Plugin
 
     protected function displayHook($type, $context)
     {
-        $element = $context['element'] ?? null;
+        $element = null;
+
+        if (!empty($context['element'])) {
+            $element = $context['element'];
+        }
+        else if (!empty($context['category'])) {
+            $element = $context['category'];
+        }
 
         if ($element) {
             switch ($type) {


### PR DESCRIPTION
For some reason Craft doesn't pass Categories in to the template as `element` it passes it in as a `category` variable. This accounts for that as well as your existing "what if `element` doesn't exist at all."